### PR TITLE
RichText: Add support for embedded videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tiptap/extension-link": "^2.0.3",
     "@tiptap/extension-placeholder": "^2.0.3",
     "@tiptap/extension-typography": "^2.0.3",
+    "@tiptap/extension-youtube": "^2.0.3",
     "@tiptap/pm": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",

--- a/src/example/index.css
+++ b/src/example/index.css
@@ -79,8 +79,27 @@
 
 /* Display TipTap Editor placeholder for `StructuredRichText` component */
 .vnf-richtext-input {
-  .ProseMirror p.is-editor-empty:first-child::before {
+  & .ProseMirror p.is-editor-empty:first-child::before {
     @apply vnf-text-gray-300 vnf-float-left vnf-h-0 vnf-pointer-events-none;
     @apply vnf-content-[attr(data-placeholder)];
+  }
+
+    /* Display frame for TipTap youtube extension video so it can be draggable */
+  & .ProseMirror-selectednode iframe {
+    transition: outline 0.15s;
+    outline: 6px solid #ece111;
+  }
+
+  & iframe {
+    border: 8px solid #000;
+    border-radius: 4px;
+    min-width: 200px;
+    min-height: 200px;
+    display: block;
+    outline: 0px solid transparent;
+  }
+  & div[data-youtube-video] {
+    cursor: move;
+    padding-right: 24px;
   }
 }

--- a/src/lib/components/structured/RichText.vue
+++ b/src/lib/components/structured/RichText.vue
@@ -35,6 +35,7 @@ import { Typography } from '@tiptap/extension-typography';
 import Placeholder from '@tiptap/extension-placeholder'
 import Image from '@tiptap/extension-image'
 import Youtube from '@tiptap/extension-youtube'
+import IFrame from '../../../util/tiptap-extensions/iframe';
 import TiptapMenuBar from './TiptapMenuBar.vue';
 import { Field } from '../../forms';
 
@@ -77,6 +78,7 @@ const editor = useEditor({
     Youtube.configure({
       controls: false,
     }),
+    IFrame,
   ],
   onUpdate: () => {
     const value = editor.value.getHTML()

--- a/src/lib/components/structured/RichText.vue
+++ b/src/lib/components/structured/RichText.vue
@@ -7,7 +7,11 @@
     <div class='vnf-richtext-input tiptap-editor' v-if='editor'>
       <label v-if='!hideLabel' :for='uid' class='vnf-label'>{{ label }}</label>
       <slot name='menuBar' v-bind='editor'>
-        <TiptapMenuBar :editor='editor' />
+        <TiptapMenuBar
+          :editor="editor"
+          :menu-items="menuItemsConfig"
+          @mitem:click="(param) => $emit('mitem:click', param)"
+        />
       </slot>
       <EditorContent
         :id='uid'
@@ -38,7 +42,7 @@ import Youtube from '@tiptap/extension-youtube'
 import IFrame from '../../../util/tiptap-extensions/iframe';
 import TiptapMenuBar from './TiptapMenuBar.vue';
 import { Field } from '../../forms';
-import { RichTextMenuItemEnum, RichTextMenuItemConfig } from '../../../util/enums';
+import { RichTextMenuItemEnum, type RichTextMenuItemConfig } from '../../../util/enums';
 
 const fieldRef = ref(null);
 
@@ -52,10 +56,11 @@ interface Props {
   contentClass?: string;
   overrideValue?: string;
   placeholder?: string;
-  menuitemsConfig?: RichTextMenuItemConfig;
+  menuItemsConfig?: RichTextMenuItemConfig;
 }
 
-const defaultMenuItemConfig = [
+const props = withDefaults(defineProps<Props>(), {
+  menuItemsConfig: () => [
   { type: RichTextMenuItemEnum.BOLD, manual: false },
   { type: RichTextMenuItemEnum.ITALIC, manual: false },
   { type: RichTextMenuItemEnum.STRIKE, manual: false },
@@ -77,14 +82,12 @@ const defaultMenuItemConfig = [
   { type: RichTextMenuItemEnum.DIVIDER, manual: false },
   { type: RichTextMenuItemEnum.UNDO, manual: false },
   { type: RichTextMenuItemEnum.REDO, manual: false },
-];
-
-const props = withDefaults(defineProps<Props>(), {
-  menuitemsConfig: defaultMenuItemConfig,
+],
 });
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void
+  (e: 'mitem:click', payload: { type: RichTextMenuItemEnum, action: Function }): void
 }>()
 
 const value = computed(() => <string>fieldRef.value?.value || '')

--- a/src/lib/components/structured/RichText.vue
+++ b/src/lib/components/structured/RichText.vue
@@ -34,6 +34,7 @@ import { Highlight } from '@tiptap/extension-highlight';
 import { Typography } from '@tiptap/extension-typography';
 import Placeholder from '@tiptap/extension-placeholder'
 import Image from '@tiptap/extension-image'
+import Youtube from '@tiptap/extension-youtube'
 import TiptapMenuBar from './TiptapMenuBar.vue';
 import { Field } from '../../forms';
 
@@ -73,6 +74,9 @@ const editor = useEditor({
       placeholder: props.placeholder,
     }),
     Image,
+    Youtube.configure({
+      controls: false,
+    }),
   ],
   onUpdate: () => {
     const value = editor.value.getHTML()

--- a/src/lib/components/structured/RichText.vue
+++ b/src/lib/components/structured/RichText.vue
@@ -38,6 +38,7 @@ import Youtube from '@tiptap/extension-youtube'
 import IFrame from '../../../util/tiptap-extensions/iframe';
 import TiptapMenuBar from './TiptapMenuBar.vue';
 import { Field } from '../../forms';
+import { RichTextMenuItemEnum, RichTextMenuItemConfig } from '../../../util/enums';
 
 const fieldRef = ref(null);
 
@@ -51,8 +52,36 @@ interface Props {
   contentClass?: string;
   overrideValue?: string;
   placeholder?: string;
+  menuitemsConfig?: RichTextMenuItemConfig;
 }
-const props = defineProps<Props>()
+
+const defaultMenuItemConfig = [
+  { type: RichTextMenuItemEnum.BOLD, manual: false },
+  { type: RichTextMenuItemEnum.ITALIC, manual: false },
+  { type: RichTextMenuItemEnum.STRIKE, manual: false },
+  { type: RichTextMenuItemEnum.CODE, manual: false },
+  { type: RichTextMenuItemEnum.LINK, manual: false },
+  { type: RichTextMenuItemEnum.IMAGE, manual: false },
+  { type: RichTextMenuItemEnum.EMBED, manual: false },
+  { type: RichTextMenuItemEnum.YOUTUBE, manual: false },
+  { type: RichTextMenuItemEnum.DIVIDER, manual: false },
+  { type: RichTextMenuItemEnum.HEADING_1, manual: false },
+  { type: RichTextMenuItemEnum.HEADING_2, manual: false },
+  { type: RichTextMenuItemEnum.PARAGRAPH, manual: false },
+  { type: RichTextMenuItemEnum.BULLET_LIST, manual: false },
+  { type: RichTextMenuItemEnum.ORDERED_LIST, manual: false },
+  { type: RichTextMenuItemEnum.DIVIDER, manual: false },
+  { type: RichTextMenuItemEnum.BLOCKQUOTE, manual: false },
+  { type: RichTextMenuItemEnum.DIVIDER, manual: false },
+  { type: RichTextMenuItemEnum.CLEAR_FORMAT, manual: false },
+  { type: RichTextMenuItemEnum.DIVIDER, manual: false },
+  { type: RichTextMenuItemEnum.UNDO, manual: false },
+  { type: RichTextMenuItemEnum.REDO, manual: false },
+];
+
+const props = withDefaults(defineProps<Props>(), {
+  menuitemsConfig: defaultMenuItemConfig,
+});
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -90,6 +90,22 @@ const items = [
       props.editor.chain().focus().setImage({ src: url }).run();
     },
     isActive: () => props.editor.isActive('highlight'),
+  {
+    icon: Iframe,
+    title: 'Embed',
+    action: () => {
+      let previousIframe = props.editor.getAttributes("iframe").src;
+      const url = window.prompt("Please enter link from embedded video:", previousIframe);
+      if (url === null) {
+        return;
+      }
+      props.editor
+        .chain()
+        .focus()
+        .setIframe({ src: url })
+        .run();
+    },
+    isActive: () => props.editor.isActive("iframe"),
   },
   {
     icon: Youtube,

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -113,16 +113,22 @@ const menuItemTemplate = [
   {
     icon: Iframe,
     title: RichTextMenuItemEnum.EMBED,
-    action: () => {
-      let previousIframe = props.editor.getAttributes("iframe").src;
-      const url = window.prompt("Please enter link from embedded video:", previousIframe);
-      if (url === null) {
-        return;
+    action: (url?: string, config = {}) => {
+      let inputUrl = url;
+      if (!url) {
+        let previousIframe = props.editor.getAttributes("iframe").src;
+        inputUrl = window.prompt(
+          "Please enter link for embed:",
+          previousIframe
+        );
+        if (inputUrl === null) {
+          return;
+        }
       }
       props.editor
         .chain()
         .focus()
-        .setIframe({ src: url })
+        .setIframe({ src: inputUrl, ...config })
         .run();
     },
     isActive: () => props.editor.isActive("iframe"),
@@ -130,16 +136,19 @@ const menuItemTemplate = [
   {
     icon: Youtube,
     title: RichTextMenuItemEnum.YOUTUBE,
-    action: () => {
-      let previousYt = props.editor.getAttributes("youtube").src;
-      const url = window.prompt("Please enter youtube link:", previousYt);
-      if (url === null) {
-        return;
+    action: (url?: string, config = {}) => {
+      let inputUrl = url;
+      if (!url) {
+        let previousIframe = props.editor.getAttributes("youtube").src;
+        inputUrl = window.prompt("Please enter youtube link:", previousIframe);
+        if (inputUrl === null) {
+          return;
+        }
       }
       props.editor
         .chain()
         .focus()
-        .setYoutubeVideo({ src: url })
+        .setYoutubeVideo({ src: inputUrl, ...config })
         .run();
     },
     isActive: () => props.editor.isActive("youtube"),

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -34,7 +34,9 @@ import {
   FormatParagraph,
   FormatQuoteClose,
   FormatStrikethrough,
+  FormatTextWrappingWrap,
   LinkVariant,
+  Minus,
   Redo,
   Undo,
   Image,
@@ -187,27 +189,21 @@ const menuItemTemplate = [
     isActive: () => props.editor.isActive('orderedList'),
   },
   {
-    title: RichTextMenuItemEnum.DIVIDER,
-  },
-  {
     icon: FormatQuoteClose,
     title: RichTextMenuItemEnum.BLOCKQUOTE,
     action: () => props.editor.chain().focus().toggleBlockquote().run(),
     isActive: () => props.editor.isActive('blockquote'),
   },
-  // {
-  //   icon: 'separator',
-  //   title: RichTextMenuItemEnum.HORIZONTAL_RULE,
-  //   action: () => props.editor.chain().focus().setHorizontalRule().run(),
-  // },
   {
-    title: RichTextMenuItemEnum.DIVIDER,
+    icon: Minus,
+    title: RichTextMenuItemEnum.HORIZONTAL_RULE,
+    action: () => props.editor.chain().focus().setHorizontalRule().run(),
   },
-  // {
-  //   icon: 'text-wrap',
-  //   title: RichTextMenuItemEnum.HARD_BREAK,
-  //   action: () => props.editor.chain().focus().setHardBreak().run(),
-  // },
+  {
+    icon: FormatTextWrappingWrap,
+    title: RichTextMenuItemEnum.HARD_BREAK,
+    action: () => props.editor.chain().focus().setHardBreak().run(),
+  },
   {
     icon: FormatClear,
     title: RichTextMenuItemEnum.CLEAR_FORMAT,
@@ -216,9 +212,6 @@ const menuItemTemplate = [
         .clearNodes()
         .unsetAllMarks()
         .run(),
-  },
-  {
-    title: RichTextMenuItemEnum.DIVIDER,
   },
   {
     icon: Undo,

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -9,6 +9,7 @@
 
 <script setup lang='ts'>
 import MenuItem from './TiptapMenuItem.vue';
+import { RichTextMenuItemEnum } from '../../../util/enums';
 import type { Editor } from '@tiptap/vue-3';
 import {
   CodeTags,
@@ -26,6 +27,7 @@ import {
   Redo,
   Undo,
   Image,
+  Iframe,
 } from 'mdue';
 
 interface Props {
@@ -36,31 +38,31 @@ const props = defineProps<Props>()
 const items = [
   {
     icon: FormatBold,
-    title: 'Bold',
+    title: RichTextMenuItemEnum.BOLD,
     action: () => props.editor.chain().focus().toggleBold().run(),
     isActive: () => props.editor.isActive('bold'),
   },
   {
     icon: FormatItalic,
-    title: 'Italic',
+    title: RichTextMenuItemEnum.ITALIC,
     action: () => props.editor.chain().focus().toggleItalic().run(),
     isActive: () => props.editor.isActive('italic'),
   },
   {
     icon: FormatStrikethrough,
-    title: 'Strike',
+    title: RichTextMenuItemEnum.STRIKE,
     action: () => props.editor.chain().focus().toggleStrike().run(),
     isActive: () => props.editor.isActive('strike'),
   },
   {
     icon: CodeTags,
-    title: 'Code',
+    title: RichTextMenuItemEnum.CODE,
     action: () => props.editor.chain().focus().toggleCode().run(),
     isActive: () => props.editor.isActive('code'),
   },
   {
     icon: LinkVariant,
-    title: 'Link',
+    title: RichTextMenuItemEnum.LINK,
     action: () => {
       const previousUrl = props.editor.getAttributes('link').href
       const url = window.prompt('URL', previousUrl)
@@ -80,19 +82,20 @@ const items = [
   },
   {
     icon: Image,
-    title: 'Image',
+    title: RichTextMenuItemEnum.IMAGE,
     action: () => {
       let previousImg = props.editor.getAttributes('image').src;
-      const url = window.prompt('URL', previousImg);
+      const url = window.prompt('Please enter image URL:', previousImg);
       if (url === null) {
         return;
       }
       props.editor.chain().focus().setImage({ src: url }).run();
     },
-    isActive: () => props.editor.isActive('highlight'),
+    isActive: () => props.editor.isActive('image'),
+  },
   {
     icon: Iframe,
-    title: 'Embed',
+    title: RichTextMenuItemEnum.EMBED,
     action: () => {
       let previousIframe = props.editor.getAttributes("iframe").src;
       const url = window.prompt("Please enter link from embedded video:", previousIframe);
@@ -109,7 +112,7 @@ const items = [
   },
   {
     icon: Youtube,
-    title: 'Youtube',
+    title: RichTextMenuItemEnum.YOUTUBE,
     action: () => {
       let previousYt = props.editor.getAttributes("youtube").src;
       const url = window.prompt("Please enter youtube link:", previousYt);
@@ -125,60 +128,63 @@ const items = [
     isActive: () => props.editor.isActive("youtube"),
   },
   {
+    title: RichTextMenuItemEnum.DIVIDER,
+  },
+  {
     icon: FormatHeader_1,
-    title: 'Heading 1',
+    title: RichTextMenuItemEnum.HEADING_1,
     action: () => props.editor.chain().focus().toggleHeading({ level: 1 }).run(),
     isActive: () => props.editor.isActive('heading', { level: 1 }),
   },
   {
     icon: FormatHeader_2,
-    title: 'Heading 2',
+    title: RichTextMenuItemEnum.HEADING_2,
     action: () => props.editor.chain().focus().toggleHeading({ level: 2 }).run(),
     isActive: () => props.editor.isActive('heading', { level: 2 }),
   },
   {
     icon: FormatParagraph,
-    title: 'Paragraph',
+    title: RichTextMenuItemEnum.PARAGRAPH,
     action: () => props.editor.chain().focus().setParagraph().run(),
     isActive: () => props.editor.isActive('paragraph'),
   },
   {
     icon: FormatListBulleted,
-    title: 'Bullet List',
+    title: RichTextMenuItemEnum.BULLET_LIST,
     action: () => props.editor.chain().focus().toggleBulletList().run(),
     isActive: () => props.editor.isActive('bulletList'),
   },
   {
     icon: FormatListNumbered,
-    title: 'Ordered List',
+    title: RichTextMenuItemEnum.ORDERED_LIST,
     action: () => props.editor.chain().focus().toggleOrderedList().run(),
     isActive: () => props.editor.isActive('orderedList'),
   },
   {
-    type: 'divider',
+    title: RichTextMenuItemEnum.DIVIDER,
   },
   {
     icon: FormatQuoteClose,
-    title: 'Blockquote',
+    title: RichTextMenuItemEnum.BLOCKQUOTE,
     action: () => props.editor.chain().focus().toggleBlockquote().run(),
     isActive: () => props.editor.isActive('blockquote'),
   },
   // {
   //   icon: 'separator',
-  //   title: 'Horizontal Rule',
+  //   title: RichTextMenuItemEnum.HORIZONTAL_RULE,
   //   action: () => props.editor.chain().focus().setHorizontalRule().run(),
   // },
   {
-    type: 'divider',
+    title: RichTextMenuItemEnum.DIVIDER,
   },
   // {
   //   icon: 'text-wrap',
-  //   title: 'Hard Break',
+  //   title: RichTextMenuItemEnum.HARD_BREAK,
   //   action: () => props.editor.chain().focus().setHardBreak().run(),
   // },
   {
     icon: FormatClear,
-    title: 'Clear Format',
+    title: RichTextMenuItemEnum.CLEAR_FORMAT,
     action: () => props.editor.chain()
         .focus()
         .clearNodes()
@@ -186,16 +192,16 @@ const items = [
         .run(),
   },
   {
-    type: 'divider',
+    title: RichTextMenuItemEnum.DIVIDER,
   },
   {
     icon: Undo,
-    title: 'Undo',
+    title: RichTextMenuItemEnum.UNDO,
     action: () => props.editor.chain().focus().undo().run(),
   },
   {
     icon: Redo,
-    title: 'Redo',
+    title: RichTextMenuItemEnum.REDO,
     action: () => props.editor.chain().focus().redo().run(),
   },
 ]

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -1,15 +1,26 @@
 <template>
-  <div class='menu-bar'>
-    <template v-for="(item, index) in items">
-      <div class="divider" v-if="item.type === 'divider'" :key="`divider${index}`" />
-      <menu-item tabindex='-1' v-else :key="index" v-bind="item" />
+  <div class="menu-bar">
+    <template v-for="(item, index) in menuItemsCalculated">
+      <div
+        class="divider"
+        v-if="item.type === RichTextMenuItemEnum.DIVIDER"
+        :key="`divider${index}`"
+      />
+      <menu-item
+        tabindex="-1"
+        v-else
+        :key="index"
+        v-bind="item"
+        @mitem:click="(param) => $emit('mitem:click', param)"
+      />
     </template>
   </div>
 </template>
 
-<script setup lang='ts'>
+<script setup lang="ts">
+import { ref, computed } from 'vue';
 import MenuItem from './TiptapMenuItem.vue';
-import { RichTextMenuItemEnum } from '../../../util/enums';
+import { RichTextMenuItemEnum, type RichTextMenuItemConfig } from '../../../util/enums';
 import type { Editor } from '@tiptap/vue-3';
 import {
   CodeTags,
@@ -28,14 +39,20 @@ import {
   Undo,
   Image,
   Iframe,
+  Youtube
 } from 'mdue';
 
 interface Props {
   editor: Editor;
+  menuItems?: RichTextMenuItemConfig;
 }
+
+const emit = defineEmits<{
+  (e: 'mitem:click', payload: { type: RichTextMenuItemEnum, action: Function }): void
+}>();
 const props = defineProps<Props>()
 
-const items = [
+const menuItemTemplate = [
   {
     icon: FormatBold,
     title: RichTextMenuItemEnum.BOLD,
@@ -205,4 +222,12 @@ const items = [
     action: () => props.editor.chain().focus().redo().run(),
   },
 ]
+
+const menuItemsCalculated = computed(() => {
+  return props.menuItems.map((x) => {
+    const foundItem =
+      menuItemTemplate.find((item) => item.title === x.type) || {};
+    return Object.assign({}, { ...foundItem }, { ...x });
+  });
+});
 </script>

--- a/src/lib/components/structured/TiptapMenuBar.vue
+++ b/src/lib/components/structured/TiptapMenuBar.vue
@@ -92,7 +92,21 @@ const items = [
     isActive: () => props.editor.isActive('highlight'),
   },
   {
-    type: 'divider',
+    icon: Youtube,
+    title: 'Youtube',
+    action: () => {
+      let previousYt = props.editor.getAttributes("youtube").src;
+      const url = window.prompt("Please enter youtube link:", previousYt);
+      if (url === null) {
+        return;
+      }
+      props.editor
+        .chain()
+        .focus()
+        .setYoutubeVideo({ src: url })
+        .run();
+    },
+    isActive: () => props.editor.isActive("youtube"),
   },
   {
     icon: FormatHeader_1,

--- a/src/lib/components/structured/TiptapMenuItem.vue
+++ b/src/lib/components/structured/TiptapMenuItem.vue
@@ -3,7 +3,7 @@
       class="menu-item"
       type='button'
       :class="{ 'is-active': isActive ? isActive(): null }"
-      @click="action"
+      @click.prevent="onClickHanlder"
       :title="title"
   >
     <Component :is="icon" />
@@ -11,15 +11,27 @@
 </template>
 
 <script setup lang='ts'>
+import { RichTextMenuItemEnum } from '../../../util/enums';
 
 interface Props {
   icon: unknown;
   title: string;
   action: Function;
   isActive?: Function | null;
+  manual?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
   isActive: null,
 })
 
+const emit = defineEmits<{
+  (e: 'mitem:click', payload: { type: RichTextMenuItemEnum, action: Function }): void
+}>();
+
+function onClickHanlder() {
+  if (props.manual) {
+    return emit('mitem:click', { type: props.title, action: props.action })
+  }
+  props.action(); 
+}
 </script>

--- a/src/lib/forms.ts
+++ b/src/lib/forms.ts
@@ -19,7 +19,7 @@ import StructuredCheckbox from './components/structured/Checkbox.vue';
 import StructuredRadio from './components/structured/Radio.vue';
 import StructuredTokenInput from './components/structured/TokenInput.vue';
 
-import { RichTextMenuItemEnum, RichTextMenuItemConfig } from '../util/enums';
+import { RichTextMenuItemEnum, type RichTextMenuItemConfig } from '../util/enums';
 
 import {
   useFormsStore,

--- a/src/lib/forms.ts
+++ b/src/lib/forms.ts
@@ -19,6 +19,8 @@ import StructuredCheckbox from './components/structured/Checkbox.vue';
 import StructuredRadio from './components/structured/Radio.vue';
 import StructuredTokenInput from './components/structured/TokenInput.vue';
 
+import { RichTextMenuItemEnum, RichTextMenuItemConfig } from '../util/enums';
+
 import {
   useFormsStore,
   type FormRequest
@@ -48,4 +50,7 @@ export {
   StructuredTokenInput,
   StructuredTextarea,
   StructuredRichText,
+
+  RichTextMenuItemEnum,
+  RichTextMenuItemConfig,
 };

--- a/src/util/enums.ts
+++ b/src/util/enums.ts
@@ -1,0 +1,27 @@
+export type RichTextMenuItemConfig = Array<{
+  type: RichTextMenuItemEnum;
+  manual?: boolean;
+}>;
+
+export enum RichTextMenuItemEnum {
+  BOLD = 'Bold',
+  ITALIC = 'Italic',
+  STRIKE = 'Strike',
+  CODE = 'Code',
+  LINK = 'Link',
+  IMAGE = 'Image',
+  EMBED = 'Embed',
+  YOUTUBE = 'Youtube',
+  DIVIDER = 'Divider',
+  HEADING_1 = 'Heading 1',
+  HEADING_2 = 'Heading 2',
+  PARAGRAPH = 'Paragraph',
+  BULLET_LIST = 'Bullet List',
+  ORDERED_LIST = 'Ordered List',
+  BLOCKQUOTE = 'Blockquote',
+  HORIZONTAL_RULE = 'Horizontal Rule',
+  HARD_BREAK = 'Hard Break',
+  CLEAR_FORMAT = 'Clear formatting',
+  UNDO = 'Undo',
+  REDO = 'Redo',
+};

--- a/src/util/tiptap-extensions/iframe.ts
+++ b/src/util/tiptap-extensions/iframe.ts
@@ -1,0 +1,80 @@
+import { Node } from "@tiptap/core";
+
+export interface IframeOptions {
+  allowFullscreen: boolean;
+  HTMLAttributes: {
+    [key: string]: any;
+  };
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    iframe: {
+      /**
+       * Add an iframe
+       */
+      setIframe: (options: { src: string }) => ReturnType;
+    };
+  }
+}
+
+export default Node.create<IframeOptions>({
+  name: "iframe",
+
+  group: "block",
+
+  atom: true,
+
+  addOptions() {
+    return {
+      allowFullscreen: true,
+      HTMLAttributes: {
+        class: "iframe-wrapper",
+      },
+    };
+  },
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+      },
+      frameborder: {
+        default: 0,
+      },
+      allowfullscreen: {
+        default: this.options.allowFullscreen,
+        parseHTML: () => this.options.allowFullscreen,
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "iframe",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", this.options.HTMLAttributes, ["iframe", HTMLAttributes]];
+  },
+
+  addCommands() {
+    return {
+      setIframe:
+        (options: { src: string }) =>
+        ({ tr, dispatch }) => {
+          const { selection } = tr;
+          const node = this.type.create(options);
+
+          if (dispatch) {
+            tr.replaceRangeWith(selection.from, selection.to, node);
+          }
+
+          return true;
+        },
+    };
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-typography/-/extension-typography-2.0.3.tgz#fc3e9a5e15cfd9fa041315437a46681c3b0b5d51"
   integrity sha512-5U91O2dffYOvwenWG+zT1N/pnt+RppSlocxs1KaNWFLlI2fgzDTyUyjzygIHGmskStqay2MuvmPnfVABoC+1Gw==
 
+"@tiptap/extension-youtube@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-youtube/-/extension-youtube-2.0.3.tgz#caeab5473eb6a69314ef6733772c3c2c6de5c2ad"
+  integrity sha512-iZsMr+88I3hvfbJNLmiPsz2/8ZGpMucyCxRbrZGg1D6wBw4oiUhRPHzGJ3APlECzpanCjyQNMHIk/gvSDDX3ig==
+
 "@tiptap/pm@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@tiptap/pm/-/pm-2.0.3.tgz#e8bb47df765fc1b7acd52f2800c52d7ff945c5ec"


### PR DESCRIPTION
Support for insert of embed links was added. User can now insert embeds from vimeo, soundcloud, spotify, bandcamp by inserting url from embeds. Input can be done by default through alert or manually by triggering action that was passed outside of library so that way we can have more customizable UI by using some kind of modal, confirm screen and so on.

Enums and types for menu items of tiptap editor is now exported so user can later combine certain items as they please by using on component prop: `menuItemsConfig` and passing actions they want and also in order they want. This way we can utilise this in future for having editor in let's full mode where all text edit options are enabled (like in word) or maybe more compact like we currently have.

For youtube video extension was also added and user can click on youtube menu item action or either just paste the link in editor in order to insert it. For embed/iframe custom extension was created as this was needed.